### PR TITLE
Fix YAML syntax in Claude workflow commit message

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,11 +69,11 @@ jobs:
             git add .
             
             # Commit with a descriptive message
-            git commit -m "Claude Code: Auto-commit changes made by AI assistant
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>" || echo "No changes to commit"
+            git commit -m "Claude Code: Auto-commit changes made by AI assistant" \
+              -m "" \
+              -m "🤖 Generated with [Claude Code](https://claude.ai/code)" \
+              -m "" \
+              -m "Co-Authored-By: Claude <noreply@anthropic.com>" || echo "No changes to commit"
             
             # Push changes back to the branch
             git push origin HEAD || echo "Failed to push changes"


### PR DESCRIPTION
## Summary
- Fix YAML parsing error in Claude workflow auto-commit step
- Split multi-line commit message into separate -m flags
- Ensures proper bash command execution in workflow

## Changes
- Updated commit command to use multiple -m flags instead of multi-line string
- Prevents YAML syntax errors when workflow executes

## Test plan
- [x] Verify YAML syntax is valid
- [x] Confirm commit message formatting works correctly
- [x] Test workflow can execute without syntax errors

🤖 Generated with [Claude Code](https://claude.ai/code)