### PR TITLE
Remove auto-commit section from Claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -56,36 +56,3 @@ jobs:
           # Optional: Custom environment variables for Claude
           # claude_env: |
           #   NODE_ENV: test
-
-      - name: Commit changes made by Claude
-        if: always()
-        env:
-          GITHUB_TOKEN: ${{ secrets.SYNC_PAT }}
-        run: |
-          git config --local user.email "claude@anthropic.com"
-          git config --local user.name "Claude Code"
-          
-          # Show current branch for visibility
-          echo "Current branch: $(git branch --show-current)"
-          
-          # Check for any changes (tracked, staged, or untracked)
-          git add .
-          
-          # Check if there are changes to commit after adding
-          if ! git diff --cached --quiet; then
-            echo "Changes detected, committing..."
-            
-            # Commit with a descriptive message
-            git commit -m "Claude Code: Auto-commit changes made by AI assistant" \
-              -m "" \
-              -m "🤖 Generated with [Claude Code](https://claude.ai/code)" \
-              -m "" \
-              -m "Co-Authored-By: Claude <noreply@anthropic.com>"
-            
-            # Push changes back to the branch using SYNC_PAT
-            echo "Pushing to branch: $(git branch --show-current)"
-            git push origin HEAD
-            echo "Changes successfully committed and pushed"
-          else
-            echo "No changes detected after adding files"
-          fi


### PR DESCRIPTION
## Summary
- Remove auto-commit functionality that was blocked by GitHub security restrictions
- GitHub Apps cannot modify workflow files regardless of tokens or permissions
- Simplify workflow to focus on Claude execution only

## Problem
GitHub prevents Apps from modifying workflow files as a security measure, causing the auto-commit step to fail even with SYNC_PAT token.

## Solution
- Remove the entire auto-commit step
- Claude will create files but won't attempt to commit them
- For workflow files, Claude can create them in alternative locations for manual deployment

## Test plan
- [x] Verify workflow runs without commit step
- [x] Confirm Claude can still create files (just not commit them)
- [x] Test workflow completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)